### PR TITLE
Add sample deck and shared utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,15 @@ We will have:
 The deck model will be contained on a json schema with multiple fields so each question can be represented in different ways, variations or interfaces.s
 
 We will have a separate mode for soroban like math challenges with a graphical interface (this wont use AI for bovious)
+## Adding More Decks
+
+1. Install dependencies and run the development server:
+   ```bash
+   cd apps/frontend
+   npm install
+   npm run dev
+   ```
+2. Open `http://localhost:3000/decks/create` and use the form to build a new deck.
+   The deck will be saved as a JSON file under `shared/data/decks`.
+3. You can also create deck JSON files manually. Use `shared/data/decks/spanish-basics.json`
+   as a template and place additional files in the same directory.

--- a/shared/data/decks/spanish-basics.json
+++ b/shared/data/decks/spanish-basics.json
@@ -1,0 +1,31 @@
+{
+  "id": "deck-spanish-basics",
+  "title": "Spanish Basics",
+  "description": "Essential Spanish vocabulary for beginners",
+  "concepts": [
+    {
+      "conceptType": "term",
+      "term": "Hola",
+      "definition": "Hello",
+      "variations": [
+        {"type": "example", "text": "Hola, ¿cómo estás?"}
+      ]
+    },
+    {
+      "conceptType": "term",
+      "term": "Adiós",
+      "definition": "Goodbye",
+      "variations": [
+        {"type": "example", "text": "Adiós, hasta luego"}
+      ]
+    },
+    {
+      "conceptType": "term",
+      "term": "Gracias",
+      "definition": "Thank you",
+      "variations": [
+        {"type": "example", "text": "Gracias por tu ayuda"}
+      ]
+    }
+  ]
+}

--- a/shared/lib/card-generator.ts
+++ b/shared/lib/card-generator.ts
@@ -1,0 +1,12 @@
+import { Deck } from '../schemas/deck';
+import { Flashcard } from '../schemas/cards';
+
+export function generateFlashcards(deck: Deck): Flashcard[] {
+  return deck.concepts.map((concept, idx) => ({
+    id: `${deck.id}-${idx}`,
+    data: {
+      front: concept.term,
+      back: concept.definition,
+    },
+  }));
+}

--- a/shared/lib/deck-service.ts
+++ b/shared/lib/deck-service.ts
@@ -1,0 +1,34 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import { Deck, DeckSchema } from '../schemas/deck';
+
+const DECKS_DIR = path.join(process.cwd(), 'shared/data/decks');
+
+export class DeckService {
+  static async loadDeck(fileName: string): Promise<Deck | null> {
+    try {
+      const filePath = path.join(DECKS_DIR, `${fileName}.json`);
+      const data = await fs.readFile(filePath, 'utf8');
+      return DeckSchema.parse(JSON.parse(data));
+    } catch {
+      return null;
+    }
+  }
+
+  static async getAllDecksInfo(): Promise<Array<{ fileName: string; deck: Deck }>> {
+    try {
+      const files = await fs.readdir(DECKS_DIR);
+      const decks: Array<{ fileName: string; deck: Deck }> = [];
+      for (const file of files) {
+        if (!file.endsWith('.json')) continue;
+        const fileName = path.parse(file).name;
+        const data = await fs.readFile(path.join(DECKS_DIR, file), 'utf8');
+        const deck = DeckSchema.parse(JSON.parse(data));
+        decks.push({ fileName, deck });
+      }
+      return decks;
+    } catch {
+      return [];
+    }
+  }
+}

--- a/shared/lib/utils.ts
+++ b/shared/lib/utils.ts
@@ -1,0 +1,1 @@
+export const generateId = (): string => Math.random().toString(36).substr(2, 9);

--- a/shared/schemas/cards.ts
+++ b/shared/schemas/cards.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod';
+
+export const FlashcardSchema = z.object({
+  id: z.string(),
+  data: z.object({
+    front: z.string(),
+    back: z.string(),
+  }),
+});
+
+export type Flashcard = z.infer<typeof FlashcardSchema>;

--- a/shared/schemas/concepts.ts
+++ b/shared/schemas/concepts.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod';
+
+export const VariationSchema = z.object({
+  type: z.string(),
+  text: z.string(),
+});
+export type Variation = z.infer<typeof VariationSchema>;
+
+export const TermConceptSchema = z.object({
+  conceptType: z.literal('term'),
+  term: z.string(),
+  definition: z.string(),
+  variations: z.array(VariationSchema).optional(),
+});
+export type TermConcept = z.infer<typeof TermConceptSchema>;
+
+export const ConceptSchema = TermConceptSchema;
+export type Concept = z.infer<typeof ConceptSchema>;

--- a/shared/schemas/deck.ts
+++ b/shared/schemas/deck.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod';
+import { ConceptSchema } from './concepts';
+
+export const DeckSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  description: z.string().optional(),
+  concepts: z.array(ConceptSchema),
+});
+
+export type Deck = z.infer<typeof DeckSchema>;


### PR DESCRIPTION
## Summary
- provide an example deck (`spanish-basics.json`)
- implement `DeckService` and simple flashcard generator under `shared/lib`
- add minimal schemas for decks, concepts and cards
- update README with instructions on creating new decks

## Testing
- `npm install --force` *(fails: Config issues during lint)*
- `npm run lint` *(fails: Next.js config error)*

------
https://chatgpt.com/codex/tasks/task_e_684a63a5cd08832a9805bfbce2658c01