### PR TITLE
Clean up merge artifacts in shared modules

### DIFF
--- a/shared/lib/card-generator.ts
+++ b/shared/lib/card-generator.ts
@@ -1,59 +1,34 @@
-<<<<<<< HEAD
-<<<<<<< HEAD
-import type { Deck } from "../schemas/deck";
-import type { Concept } from "../schemas/concepts";
-import type { Flashcard } from "../schemas/cards";
+import type { Deck } from '../schemas/deck';
+import type { Flashcard } from '../schemas/cards';
 
 /**
  * Generates a list of flashcards from a deck's concepts.
- * 
- * @param deck The deck containing the concepts.
- * @returns An array of flashcards.
+ * Each term concept yields two cards: term -> definition and definition -> term.
  */
 export function generateFlashcards(deck: Deck): Flashcard[] {
   const flashcards: Flashcard[] = [];
 
   for (const concept of deck.concepts) {
-    if (concept.conceptType === "term") {
-      // Create a standard flashcard (term -> definition)
+    if (concept.conceptType === 'term') {
+      // Standard card (term -> definition)
       flashcards.push({
-        cardType: "flashcard",
+        cardType: 'flashcard',
         data: {
           front: concept.term,
           back: concept.definition,
         },
       });
 
-      // Create a reverse flashcard (definition -> term)
+      // Reverse card (definition -> term)
       flashcards.push({
-        cardType: "flashcard",
+        cardType: 'flashcard',
         data: {
           front: concept.definition,
           back: concept.term,
         },
       });
     }
-    // In the future, other concept types could also generate flashcards
   }
 
   return flashcards;
-} 
-=======
-=======
->>>>>>> 85b5c276ec45cbf76a8a69c7fa290c5b64704bc2
-import { Deck } from '../schemas/deck';
-import { Flashcard } from '../schemas/cards';
-
-export function generateFlashcards(deck: Deck): Flashcard[] {
-  return deck.concepts.map((concept, idx) => ({
-    id: `${deck.id}-${idx}`,
-    data: {
-      front: concept.term,
-      back: concept.definition,
-    },
-  }));
 }
-<<<<<<< HEAD
->>>>>>> 85b5c276ec45cbf76a8a69c7fa290c5b64704bc2
-=======
->>>>>>> 85b5c276ec45cbf76a8a69c7fa290c5b64704bc2

--- a/shared/lib/deck-service.ts
+++ b/shared/lib/deck-service.ts
@@ -1,7 +1,5 @@
 import { promises as fs } from 'fs';
 import path from 'path';
-<<<<<<< HEAD
-<<<<<<< HEAD
 import { DeckSchema, type Deck } from '../schemas/deck';
 
 /**
@@ -18,37 +16,16 @@ export class DeckService {
       const filePath = path.join(this.deckDirectory, `${deckFileName}.json`);
       const fileContent = await fs.readFile(filePath, 'utf8');
       const data = JSON.parse(fileContent);
-      
+
       // Validate data against our schema
       const deck = DeckSchema.parse(data);
       return deck;
-
     } catch (error) {
       console.error(`Failed to load deck "${deckFileName}":`, error);
-=======
-=======
->>>>>>> 85b5c276ec45cbf76a8a69c7fa290c5b64704bc2
-import { Deck, DeckSchema } from '../schemas/deck';
-
-const DECKS_DIR = path.join(process.cwd(), 'shared/data/decks');
-
-export class DeckService {
-  static async loadDeck(fileName: string): Promise<Deck | null> {
-    try {
-      const filePath = path.join(DECKS_DIR, `${fileName}.json`);
-      const data = await fs.readFile(filePath, 'utf8');
-      return DeckSchema.parse(JSON.parse(data));
-    } catch {
-<<<<<<< HEAD
->>>>>>> 85b5c276ec45cbf76a8a69c7fa290c5b64704bc2
-=======
->>>>>>> 85b5c276ec45cbf76a8a69c7fa290c5b64704bc2
       return null;
     }
   }
 
-<<<<<<< HEAD
-<<<<<<< HEAD
   /**
    * Lists all available deck files
    */
@@ -69,7 +46,7 @@ export class DeckService {
    */
   static async getAllDecksInfo(): Promise<Array<{ fileName: string; deck: Deck }>> {
     const deckFiles = await this.listAvailableDecks();
-    const decks = [];
+    const decks: Array<{ fileName: string; deck: Deck }> = [];
 
     for (const fileName of deckFiles) {
       const deck = await this.loadDeck(fileName);
@@ -80,28 +57,4 @@ export class DeckService {
 
     return decks;
   }
-} 
-=======
-=======
->>>>>>> 85b5c276ec45cbf76a8a69c7fa290c5b64704bc2
-  static async getAllDecksInfo(): Promise<Array<{ fileName: string; deck: Deck }>> {
-    try {
-      const files = await fs.readdir(DECKS_DIR);
-      const decks: Array<{ fileName: string; deck: Deck }> = [];
-      for (const file of files) {
-        if (!file.endsWith('.json')) continue;
-        const fileName = path.parse(file).name;
-        const data = await fs.readFile(path.join(DECKS_DIR, file), 'utf8');
-        const deck = DeckSchema.parse(JSON.parse(data));
-        decks.push({ fileName, deck });
-      }
-      return decks;
-    } catch {
-      return [];
-    }
-  }
 }
-<<<<<<< HEAD
->>>>>>> 85b5c276ec45cbf76a8a69c7fa290c5b64704bc2
-=======
->>>>>>> 85b5c276ec45cbf76a8a69c7fa290c5b64704bc2

--- a/shared/schemas/cards.ts
+++ b/shared/schemas/cards.ts
@@ -1,38 +1,17 @@
-<<<<<<< HEAD
-<<<<<<< HEAD
-import { z } from "zod";
-
-// This file will contain the schemas for the "playable" cards
-// that are generated on-the-fly from concepts.
-
-export const FlashcardSchema = z.object({
-  cardType: z.literal("flashcard"),
-=======
-=======
->>>>>>> 85b5c276ec45cbf76a8a69c7fa290c5b64704bc2
 import { z } from 'zod';
 
+// Schemas for playable cards generated from concepts
+
 export const FlashcardSchema = z.object({
-  id: z.string(),
-<<<<<<< HEAD
->>>>>>> 85b5c276ec45cbf76a8a69c7fa290c5b64704bc2
-=======
->>>>>>> 85b5c276ec45cbf76a8a69c7fa290c5b64704bc2
+  cardType: z.literal('flashcard'),
   data: z.object({
     front: z.string(),
     back: z.string(),
   }),
 });
-<<<<<<< HEAD
-<<<<<<< HEAD
-export type Flashcard = z.infer<typeof FlashcardSchema>;
-
-// We will add other generated card types here, e.g., MultipleChoice 
-=======
 
 export type Flashcard = z.infer<typeof FlashcardSchema>;
->>>>>>> 85b5c276ec45cbf76a8a69c7fa290c5b64704bc2
-=======
 
-export type Flashcard = z.infer<typeof FlashcardSchema>;
->>>>>>> 85b5c276ec45cbf76a8a69c7fa290c5b64704bc2
+// Union type for different card kinds. Extend as new games are added.
+export const CardSchema = FlashcardSchema;
+export type Card = z.infer<typeof CardSchema>;

--- a/shared/schemas/concepts.ts
+++ b/shared/schemas/concepts.ts
@@ -1,30 +1,28 @@
-<<<<<<< HEAD
-<<<<<<< HEAD
-import { z } from "zod";
+import { z } from 'zod';
 
-// ---------------------------------------------------------------------------
-//  Variation helpers – keep UI and validation logic DRY
-// ---------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
+// Variation helpers – keep UI and validation logic DRY
+// -----------------------------------------------------------------------------
 
 /**
- * The set of variation categories that our UI explicitly supports.  
+ * The set of variation categories that our UI explicitly supports.
  * Validation purposely allows any string to future-proof the schema, so these
  * values are mainly used for dropdowns / styling.
  */
 export const VARIATION_TYPES = [
-  "alternative-definition",
-  "example",
-  "fun-fact",
-  "misconception",
-  "tip",
-  "explanation",
-  "historical-note",
+  'alternative-definition',
+  'example',
+  'fun-fact',
+  'misconception',
+  'tip',
+  'explanation',
+  'historical-note',
 ] as const;
 
 type VariationType = (typeof VARIATION_TYPES)[number];
 
 /**
- * A single variation of a concept (e.g. example, tip…).  
+ * A single variation of a concept (e.g. example, tip…).
  * We accept ANY string for `type` to make the schema forward-compatible, while
  * the UI still references `VARIATION_TYPES` so we have a curated list.
  */
@@ -41,45 +39,24 @@ export type Variation = z.infer<typeof VariationSchema> & { type: VariationType 
  * Represents a single piece of knowledge, like a term and its definition.
  * It can include variations to be used for generating different kinds of questions.
  */
-export const TermConceptSchema = z.object({
-  conceptType: z.literal("term"),
-  term: z.string().min(1),
-  definition: z.string().min(1),
-  // Optional variations for more diverse questions
-  variations: z.array(VariationSchema).optional(),
-}).passthrough(); // allow extra keys for future-proofing
+export const TermConceptSchema = z
+  .object({
+    conceptType: z.literal('term'),
+    term: z.string().min(1),
+    definition: z.string().min(1),
+    // Optional variations for more diverse questions
+    variations: z.array(VariationSchema).optional(),
+  })
+  .passthrough(); // allow extra keys for future-proofing
 
 export type TermConcept = z.infer<typeof TermConceptSchema>;
 
 // We will add more concept types here later (e.g., SequenceConcept, RelationConcept)
 
 // A discriminated union of all concept types.
-export const ConceptSchema = z.discriminatedUnion("conceptType", [
+export const ConceptSchema = z.discriminatedUnion('conceptType', [
   TermConceptSchema,
   // Other concept schemas will be added here
-]); 
-=======
-=======
->>>>>>> 85b5c276ec45cbf76a8a69c7fa290c5b64704bc2
-import { z } from 'zod';
+]);
 
-export const VariationSchema = z.object({
-  type: z.string(),
-  text: z.string(),
-});
-export type Variation = z.infer<typeof VariationSchema>;
-
-export const TermConceptSchema = z.object({
-  conceptType: z.literal('term'),
-  term: z.string(),
-  definition: z.string(),
-  variations: z.array(VariationSchema).optional(),
-});
-export type TermConcept = z.infer<typeof TermConceptSchema>;
-
-export const ConceptSchema = TermConceptSchema;
 export type Concept = z.infer<typeof ConceptSchema>;
-<<<<<<< HEAD
->>>>>>> 85b5c276ec45cbf76a8a69c7fa290c5b64704bc2
-=======
->>>>>>> 85b5c276ec45cbf76a8a69c7fa290c5b64704bc2

--- a/shared/schemas/deck.ts
+++ b/shared/schemas/deck.ts
@@ -1,36 +1,18 @@
-<<<<<<< HEAD
-<<<<<<< HEAD
-import { z } from "zod";
-import { ConceptSchema } from "./concepts";
+import { z } from 'zod';
+import { ConceptSchema } from './concepts';
 
 // Schema version – bump when we introduce breaking changes so tooling can
 // perform migrations if necessary.
 export const DECK_SCHEMA_VERSION = 1 as const;
 
-export const DeckSchema = z.object({
-  id: z.string().uuid(),
-  title: z.string().min(1, "Title cannot be empty."),
-  description: z.string().optional(),
-  concepts: z.array(ConceptSchema).min(1, "A deck must have at least one concept."),
-  version: z.number().optional().default(DECK_SCHEMA_VERSION),
-}).passthrough();
-
-export type Deck = z.infer<typeof DeckSchema>; 
-=======
-=======
->>>>>>> 85b5c276ec45cbf76a8a69c7fa290c5b64704bc2
-import { z } from 'zod';
-import { ConceptSchema } from './concepts';
-
-export const DeckSchema = z.object({
-  id: z.string(),
-  title: z.string(),
-  description: z.string().optional(),
-  concepts: z.array(ConceptSchema),
-});
+export const DeckSchema = z
+  .object({
+    id: z.string(),
+    title: z.string().min(1, 'Title cannot be empty.'),
+    description: z.string().optional(),
+    concepts: z.array(ConceptSchema).min(1, 'A deck must have at least one concept.'),
+    version: z.number().optional().default(DECK_SCHEMA_VERSION),
+  })
+  .passthrough();
 
 export type Deck = z.infer<typeof DeckSchema>;
-<<<<<<< HEAD
->>>>>>> 85b5c276ec45cbf76a8a69c7fa290c5b64704bc2
-=======
->>>>>>> 85b5c276ec45cbf76a8a69c7fa290c5b64704bc2


### PR DESCRIPTION
## Summary
- remove merge markers from shared utilities and schemas
- implement two-way flashcard generation
- use deck directory path `../../shared/data/decks`
- keep schema validations with optional versioning

## Testing
- `npm run lint` *(fails: prompts for config)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684a793c049c832ab49181838f7ec815