### PR TITLE
Use Geist fonts

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -21,6 +21,7 @@
     "axios": "^1.9.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "geist": "^1.4.2",
     "lucide-react": "^0.513.0",
     "next": "14.2.0",
     "next-themes": "^0.4.6",

--- a/apps/frontend/src/app/layout.tsx
+++ b/apps/frontend/src/app/layout.tsx
@@ -1,13 +1,13 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { GeistSans, GeistMono } from "geist/font";
 import "./globals.css";
 
-const geistSans = Geist({
+const geistSans = GeistSans({
   variable: "--font-geist-sans",
   subsets: ["latin"],
 });
 
-const geistMono = Geist_Mono({
+const geistMono = GeistMono({
   variable: "--font-geist-mono",
   subsets: ["latin"],
 });


### PR DESCRIPTION
## Summary
- install Geist fonts
- switch from next/font/google to Geist

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684a829314d0832ab241ce249d3765c0