### PR TITLE
Add Geist font integration

### DIFF
--- a/apps/frontend/next.config.mjs
+++ b/apps/frontend/next.config.mjs
@@ -9,6 +9,7 @@ const nextConfig = {
   experimental: {
     serverComponentsExternalPackages: ['@/shared']
   },
+  transpilePackages: ["geist"],
   webpack: (config) => {
     // Handle shared directory
     config.resolve.alias = {

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -21,6 +21,7 @@
     "axios": "^1.9.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "geist": "^1.4.2",
     "lucide-react": "^0.513.0",
     "next": "14.2.0",
     "next-themes": "^0.4.6",

--- a/apps/frontend/src/app/layout.tsx
+++ b/apps/frontend/src/app/layout.tsx
@@ -1,13 +1,14 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { GeistSans } from "geist/font/sans";
+import { GeistMono } from "geist/font/mono";
 import "./globals.css";
 
-const geistSans = Geist({
+const geistSans = GeistSans({
   variable: "--font-geist-sans",
   subsets: ["latin"],
 });
 
-const geistMono = Geist_Mono({
+const geistMono = GeistMono({
   variable: "--font-geist-mono",
   subsets: ["latin"],
 });


### PR DESCRIPTION
## Summary
- install Geist package in the frontend
- transpile Geist in Next.js config
- switch font imports to `geist/font`

## Testing
- `npm install --legacy-peer-deps` in `apps/frontend`
- `npm run dev` *(server started)*

------
https://chatgpt.com/codex/tasks/task_e_684a93750244832aae139e7ca02d3c30