### PR TITLE
Improve mobile experience

### DIFF
--- a/apps/frontend/src/app/layout.tsx
+++ b/apps/frontend/src/app/layout.tsx
@@ -15,6 +15,7 @@ const geistMono = Geist_Mono({
 export const metadata: Metadata = {
   title: "Learning App - Study with Custom Decks",
   description: "Create and study with custom learning decks. Flashcards, quizzes, and more!",
+  viewport: "width=device-width, initial-scale=1"
 };
 
 export default function RootLayout({

--- a/apps/frontend/src/app/page.tsx
+++ b/apps/frontend/src/app/page.tsx
@@ -210,7 +210,7 @@ export default function Home() {
 
         {/* Topic Tabs */}
         <Tabs value={activeTab} onValueChange={setActiveTab} className="space-y-6">
-          <TabsList className="grid w-full grid-cols-4 lg:grid-cols-7">
+          <TabsList className="grid w-full grid-cols-2 sm:grid-cols-4 lg:grid-cols-7">
             <TabsTrigger value="all">All Topics</TabsTrigger>
             {topics.map((topic) => (
               <TabsTrigger key={topic.id} value={topic.id} className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- add viewport meta tag in layout
- adjust tab grid for smaller screens

## Testing
- `npm run lint` *(fails: Failed to load config "next/typescript" to extend from.)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_684a9bde98e4832ab3ecd094369eaa69