### PR TITLE
Add Vitest TDD for deck CRUD and schemas

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "vitest run"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.1.1",
@@ -21,6 +22,7 @@
     "axios": "^1.9.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "geist": "^1.4.2",
     "lucide-react": "^0.513.0",
     "next": "15.3.3",
     "next-themes": "^0.4.6",
@@ -31,8 +33,7 @@
     "sonner": "^2.0.5",
     "tailwind-merge": "^3.3.0",
     "uuid": "^11.1.0",
-    "zod": "^3.25.57",
-    "geist": "^1.4.2"
+    "zod": "^3.25.57"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
@@ -46,6 +47,8 @@
     "eslint-config-next": "15.3.3",
     "tailwindcss": "^4",
     "tw-animate-css": "^1.3.4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vite-tsconfig-paths": "^5.1.4",
+    "vitest": "^3.2.3"
   }
 }

--- a/apps/frontend/tests/deck-api.test.ts
+++ b/apps/frontend/tests/deck-api.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { NextRequest } from 'next/server';
+import { POST as createDeck } from '../src/app/api/decks/route';
+import { GET as listDecks } from '../src/app/api/decks/route';
+import { GET as getDeck, PUT as updateDeck, DELETE as deleteDeck } from '../src/app/api/decks/[fileName]/route';
+import fs from 'fs/promises';
+import path from 'path';
+
+const deckDir = path.join(process.cwd(), '../../shared/data/decks');
+const testTitle = 'Test Deck CRUD';
+const fileName = testTitle.toLowerCase().replace(/[^a-z0-9\s-]/g, '').replace(/\s+/g, '-').trim();
+
+const newDeck = {
+  title: testTitle,
+  description: 'testing crud',
+  concepts: [
+    { conceptType: 'term', term: 'Hola', definition: 'Hello', variations: [] }
+  ]
+};
+
+beforeAll(async () => {
+  // ensure deck does not exist
+  await fs.rm(path.join(deckDir, `${fileName}.json`), { force: true });
+});
+
+afterAll(async () => {
+  await fs.rm(path.join(deckDir, `${fileName}.json`), { force: true });
+});
+
+describe('Deck API CRUD', () => {
+  it('creates, reads, updates and deletes a deck', async () => {
+    // CREATE
+    const createReq = new NextRequest('http://localhost/api/decks', {
+      method: 'POST',
+      body: JSON.stringify(newDeck),
+      headers: { 'Content-Type': 'application/json' }
+    });
+    const createRes = await createDeck(createReq);
+    const createJson = await createRes.json();
+    expect(createJson.success).toBe(true);
+    expect(createJson.data.fileName).toBe(fileName);
+
+    // LIST
+    const listRes = await listDecks();
+    const listJson = await listRes.json();
+    const found = listJson.data.find((d: any) => d.fileName === fileName);
+    expect(found).toBeTruthy();
+
+    // GET
+    const getRes = await getDeck(undefined as any, { params: Promise.resolve({ fileName }) });
+    const getJson = await getRes.json();
+    expect(getJson.data.deck.title).toBe(testTitle);
+
+    // UPDATE
+    const updatedDeck = { ...getJson.data.deck, description: 'updated' };
+    const updateReq = new NextRequest('http://localhost/api/decks/'+fileName, {
+      method: 'PUT',
+      body: JSON.stringify(updatedDeck),
+      headers: { 'Content-Type': 'application/json' }
+    });
+    const updateRes = await updateDeck(updateReq, { params: Promise.resolve({ fileName }) });
+    const updateJson = await updateRes.json();
+    expect(updateJson.success).toBe(true);
+
+    // DELETE
+    const deleteRes = await deleteDeck(undefined as any, { params: Promise.resolve({ fileName }) });
+    const deleteJson = await deleteRes.json();
+    expect(deleteJson.success).toBe(true);
+  });
+});

--- a/apps/frontend/tests/models.test.ts
+++ b/apps/frontend/tests/models.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { VariationSchema, TermConceptSchema } from '../../shared/schemas/concepts';
+import { DeckSchema, DECK_SCHEMA_VERSION } from '../../shared/schemas/deck';
+
+const validVariation = { type: 'example', text: 'Hola, ¿cómo estás?' };
+const validConcept = { conceptType: 'term', term: 'Hola', definition: 'Hello', variations: [validVariation] };
+const validDeck = { id: 'test-id', title: 'Test Deck', description: 'desc', concepts: [validConcept] };
+
+describe('VariationSchema', () => {
+  it('accepts valid variation', () => {
+    expect(VariationSchema.parse(validVariation)).toEqual(validVariation);
+  });
+
+  it('rejects invalid variation', () => {
+    expect(() => VariationSchema.parse({ type: '', text: '' })).toThrow();
+  });
+});
+
+describe('TermConceptSchema', () => {
+  it('accepts valid concept', () => {
+    expect(TermConceptSchema.parse(validConcept)).toEqual(validConcept);
+  });
+
+  it('requires term and definition', () => {
+    expect(() => TermConceptSchema.parse({ conceptType: 'term', term: '', definition: '' })).toThrow();
+  });
+});
+
+describe('DeckSchema', () => {
+  it('accepts valid deck and sets default version', () => {
+    const parsed = DeckSchema.parse({ ...validDeck });
+    expect(parsed.version).toBe(DECK_SCHEMA_VERSION);
+  });
+
+  it('requires title and at least one concept', () => {
+    expect(() => DeckSchema.parse({ id: '1', title: '', concepts: [] })).toThrow();
+  });
+});

--- a/apps/frontend/vitest.config.ts
+++ b/apps/frontend/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+import tsconfigPaths from 'vite-tsconfig-paths';
+
+const rootDir = __dirname;
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    root: rootDir,
+  },
+  plugins: [tsconfigPaths()],
+});


### PR DESCRIPTION
## Summary
- add Vitest setup in frontend app
- validate schema models with tests
- test CRUD endpoints for decks

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_684aa92fd710832a9c7708917bb73ad0