### PR TITLE
Convert main Next.js pages into SPA

### DIFF
--- a/apps/frontend/src/app/page.tsx
+++ b/apps/frontend/src/app/page.tsx
@@ -1,274 +1,29 @@
 'use client';
 
-import { useState, useEffect } from 'react';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { Plus, BookOpen, Play, Clock, Users, Shapes, TrendingUp, Target, Award } from 'lucide-react';
-import { topics } from '@/lib/mock-data';
-import { Topic } from '@/lib/types';
-import { DecksAPI } from '@/lib/api/decks';
-import type { Deck } from '@/shared/schemas/deck';
-import Link from 'next/link';
+import { useState } from 'react';
+import HomeView from '@/components/views/HomeView';
+import DeckManagerView from '@/components/views/DeckManagerView';
+import DeckDetailsView from '@/components/views/DeckDetailsView';
 
+export default function AppPage() {
+  const [view, setView] = useState<'home' | 'decks' | 'deck'>('home');
+  const [currentDeck, setCurrentDeck] = useState<string | null>(null);
 
+  const showHome = () => setView('home');
+  const showDecks = () => setView('decks');
+  const showDeck = (fileName: string) => {
+    setCurrentDeck(fileName);
+    setView('deck');
+  };
 
-const DeckCard = ({ deck, fileName }: { deck: Deck; fileName: string }) => (
-  <Card className="hover:shadow-lg transition-all hover:scale-[1.02]">
-    <CardHeader>
-      <div className="flex items-start justify-between">
-        <div className="flex-1">
-          <CardTitle className="text-lg mb-2">{deck.title}</CardTitle>
-          <CardDescription className="mb-3">
-            {deck.description}
-          </CardDescription>
-          <div className="flex items-center gap-2 mb-2">
-            <Badge variant="outline" className="text-xs">
-              <Users className="mr-1 h-3 w-3" />
-              {deck.concepts.length} concepts
-            </Badge>
-          </div>
-        </div>
-      </div>
-    </CardHeader>
-    <CardContent>
-      <div className="flex items-center justify-between mb-4">
-        <span className="text-sm text-gray-500 flex items-center gap-1">
-          <BookOpen className="h-4 w-4" />
-          {deck.concepts.length * 2} flashcards
-        </span>
-      </div>
-      
-      <div className="flex gap-2">
-        <Button variant="default" size="sm" asChild className="flex-1">
-          <Link href={`/game/flashcard/${fileName}`}>
-            <BookOpen className="mr-2 h-4 w-4" />
-            Study
-          </Link>
-        </Button>
-        <Button variant="outline" size="sm" asChild className="flex-1">
-          <Link href={`/game/quiz/${fileName}`}>
-            <Play className="mr-2 h-4 w-4" />
-            Quiz
-          </Link>
-        </Button>
-      </div>
-      <Button variant="secondary" size="sm" asChild className="w-full mt-2">
-        <Link href={`/game/matching/${fileName}`}>
-          <Shapes className="mr-2 h-4 w-4" />
-          Matching Game
-        </Link>
-      </Button>
-    </CardContent>
-  </Card>
-);
-
-const TopicSection = ({ topic, deckItems }: { topic: Topic; deckItems: Array<{ fileName: string; deck: Deck }> }) => {
   return (
-    <div className="space-y-6">
-      {/* Topic Header */}
-      <div className="flex items-center gap-3 mb-6">
-        <div className={`p-3 rounded-lg ${topic.color}`}>
-          <span className="text-2xl">{topic.icon}</span>
-        </div>
-        <div>
-          <h2 className="text-2xl font-bold text-gray-900 dark:text-white">
-            {topic.name}
-          </h2>
-          <p className="text-gray-600 dark:text-gray-400">
-            {topic.description}
-          </p>
-        </div>
-      </div>
-
-      {/* Decks Grid */}
-      {deckItems.length > 0 && (
-        <div className="space-y-4">
-          <div className="flex items-center gap-2">
-            <span className="text-sm text-gray-500">
-              ({deckItems.length} deck{deckItems.length !== 1 ? 's' : ''})
-            </span>
-          </div>
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-            {deckItems.map(({ fileName, deck }) => (
-              <DeckCard key={deck.id} deck={deck} fileName={fileName} />
-            ))}
-          </div>
-        </div>
+    <>
+      {view === 'home' && <HomeView onManageDecks={showDecks} />}
+      {view === 'decks' && <DeckManagerView onBack={showHome} onViewDeck={showDeck} />}
+      {view === 'deck' && currentDeck && (
+        <DeckDetailsView fileName={currentDeck} onBack={showDecks} />
       )}
-    </div>
-  );
-};
-
-const StatsCard = ({ title, value, description, icon: Icon }: {
-  title: string;
-  value: string | number;
-  description: string;
-  icon: React.ElementType;
-}) => (
-  <Card>
-    <CardContent className="p-6">
-      <div className="flex items-center justify-between">
-        <div>
-          <p className="text-sm font-medium text-gray-600 dark:text-gray-400">{title}</p>
-          <p className="text-2xl font-bold text-gray-900 dark:text-white">{value}</p>
-          <p className="text-xs text-gray-500 dark:text-gray-400">{description}</p>
-        </div>
-        <Icon className="h-8 w-8 text-gray-400" />
-      </div>
-    </CardContent>
-  </Card>
-);
-
-export default function Home() {
-  const [deckItems, setDeckItems] = useState<Array<{ fileName: string; deck: Deck }>>([]);
-  const [loading, setLoading] = useState(true);
-  const [activeTab, setActiveTab] = useState<string>('all');
-
-  useEffect(() => {
-    const loadDecks = async () => {
-      try {
-        const response = await DecksAPI.getAll();
-        if (response.success && response.data) {
-          setDeckItems(response.data);
-        }
-      } catch (error) {
-        console.error('Failed to load decks:', error);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    loadDecks();
-  }, []);
-
-  // Group decks by topic (we'll use a simple title-based grouping for now)
-  const groupedDeckItems = topics.reduce((acc, topic) => {
-    acc[topic.id] = deckItems.filter(({ deck }) => 
-      deck.title.toLowerCase().includes(topic.name.toLowerCase()) ||
-      (deck.description && deck.description.toLowerCase().includes(topic.name.toLowerCase()))
-    );
-    return acc;
-  }, {} as Record<string, Array<{ fileName: string; deck: Deck }>>);
-
-  // Calculate statistics
-  const totalConcepts = deckItems.reduce((acc, { deck }) => acc + deck.concepts.length, 0);
-  const avgConceptsPerDeck = deckItems.length > 0 ? Math.round(totalConcepts / deckItems.length) : 0;
-  const totalFlashcards = totalConcepts * 2; // Each concept generates 2 flashcards
-
-  return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
-      <div className="container mx-auto px-4 py-8">
-        {/* Header */}
-        <div className="flex items-center justify-between mb-8">
-          <div>
-            <h1 className="text-3xl font-bold text-gray-900 dark:text-white">
-              Learning App
-            </h1>
-            <p className="text-gray-600 dark:text-gray-400 mt-2">
-              Explore {deckItems.length} learning decks across {topics.length} topics
-            </p>
-          </div>
-          <div className="flex gap-3">
-            <Button asChild variant="outline">
-              <Link href="/decks">
-                <BookOpen className="mr-2 h-4 w-4" />
-                Manage Decks
-              </Link>
-            </Button>
-            <Button asChild>
-              <Link href="/create">
-                <Plus className="mr-2 h-4 w-4" />
-                Create Deck
-              </Link>
-            </Button>
-          </div>
-        </div>
-
-        {/* Statistics */}
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
-          <StatsCard
-            title="Total Concepts"
-            value={totalConcepts}
-            description="Ready to study"
-            icon={BookOpen}
-          />
-          <StatsCard
-            title="Flashcards"
-            value={totalFlashcards}
-            description="Generated from concepts"
-            icon={Clock}
-          />
-          <StatsCard
-            title="Average Deck Size"
-            value={avgConceptsPerDeck}
-            description="Concepts per deck"
-            icon={Target}
-          />
-        </div>
-
-        {/* Topic Tabs */}
-        <Tabs value={activeTab} onValueChange={setActiveTab} className="space-y-6">
-          <TabsList className="grid w-full grid-cols-4 lg:grid-cols-7">
-            <TabsTrigger value="all">All Topics</TabsTrigger>
-            {topics.map((topic) => (
-              <TabsTrigger key={topic.id} value={topic.id} className="flex items-center gap-2">
-                <span>{topic.icon}</span>
-                <span className="hidden sm:inline">{topic.name}</span>
-              </TabsTrigger>
-            ))}
-          </TabsList>
-
-          {/* All Topics View */}
-          <TabsContent value="all" className="space-y-12">
-            {loading ? (
-              <div className="text-center py-12">
-                <p className="text-gray-500">Loading decks...</p>
-              </div>
-            ) : (
-              topics.map((topic) => {
-                const topicDeckItems = groupedDeckItems[topic.id];
-                return topicDeckItems.length > 0 ? (
-                  <TopicSection key={topic.id} topic={topic} deckItems={topicDeckItems} />
-                ) : null;
-              })
-            )}
-          </TabsContent>
-
-          {/* Individual Topic Views */}
-          {topics.map((topic) => (
-            <TabsContent key={topic.id} value={topic.id}>
-              {loading ? (
-                <div className="text-center py-12">
-                  <p className="text-gray-500">Loading decks...</p>
-                </div>
-              ) : (
-                <TopicSection topic={topic} deckItems={groupedDeckItems[topic.id]} />
-              )}
-            </TabsContent>
-          ))}
-        </Tabs>
-
-        {/* Empty State */}
-        {!loading && deckItems.length === 0 && (
-          <div className="text-center py-12">
-            <BookOpen className="mx-auto h-12 w-12 text-gray-400" />
-            <h3 className="mt-4 text-lg font-medium text-gray-900 dark:text-white">
-              No decks yet
-            </h3>
-            <p className="mt-2 text-gray-500">
-              Create your first learning deck to get started
-            </p>
-            <Button className="mt-4" asChild>
-              <Link href="/create">
-                <Plus className="mr-2 h-4 w-4" />
-                Create Your First Deck
-              </Link>
-            </Button>
-          </div>
-        )}
-      </div>
-    </div>
+    </>
   );
 }
+

--- a/apps/frontend/src/components/views/DeckDetailsView.tsx
+++ b/apps/frontend/src/components/views/DeckDetailsView.tsx
@@ -1,0 +1,186 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { DecksAPI } from '@/lib/api/decks';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { ArrowLeft, Edit, Download, Play, FileText, Loader } from 'lucide-react';
+import type { Deck } from '@/shared/schemas/deck';
+
+interface Props {
+  fileName: string;
+  onBack: () => void;
+}
+
+export default function DeckDetailsView({ fileName, onBack }: Props) {
+  const [loading, setLoading] = useState(true);
+  const [deck, setDeck] = useState<Deck | null>(null);
+
+  useEffect(() => {
+    const loadDeck = async () => {
+      try {
+        const response = await DecksAPI.getOne(fileName);
+        if (response.success && response.data) {
+          setDeck(response.data.deck);
+        } else {
+          alert(`Failed to load deck: ${response.error}`);
+          onBack();
+        }
+      } catch (error) {
+        alert('Failed to load deck: Network error');
+        onBack();
+      } finally {
+        setLoading(false);
+      }
+    };
+    loadDeck();
+  }, [fileName, onBack]);
+
+  const handleExport = async () => {
+    if (deck) {
+      try {
+        await DecksAPI.export(fileName, deck);
+      } catch (error) {
+        alert('Export failed');
+      }
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex items-center justify-center">
+        <div className="flex items-center gap-2">
+          <Loader className="h-4 w-4 animate-spin" />
+          Loading deck...
+        </div>
+      </div>
+    );
+  }
+
+  if (!deck) {
+    return (
+      <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex items-center justify-center">
+        <div className="text-center">
+          <FileText className="mx-auto h-12 w-12 text-gray-400 mb-4" />
+          <p className="text-gray-500">Deck not found</p>
+          <Button className="mt-4" onClick={onBack}>Back to Decks</Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
+      <div className="container mx-auto px-4 py-8">
+        <div className="mb-8">
+          <div className="flex items-center gap-4 mb-4">
+            <Button variant="ghost" onClick={onBack}>
+              <ArrowLeft className="h-4 w-4" />
+            </Button>
+            <div className="flex-1">
+              <h1 className="text-3xl font-bold text-gray-900 dark:text-white">{deck.title}</h1>
+              <p className="text-gray-600 dark:text-gray-400">{deck.description || 'No description provided'}</p>
+              <div className="flex items-center gap-2 mt-2">
+                <Badge variant="secondary">{deck.concepts.length} concept{deck.concepts.length !== 1 ? 's' : ''}</Badge>
+                <Badge variant="outline" className="text-xs">{fileName}.json</Badge>
+              </div>
+            </div>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Button asChild>
+              <a href={`/game/flashcard/${fileName}`}>
+                <Play className="mr-2 h-4 w-4" />
+                Play Flashcards
+              </a>
+            </Button>
+            <Button variant="outline" asChild>
+              <a href={`/game/quiz/${fileName}`}>
+                <Play className="mr-2 h-4 w-4" />
+                Play Quiz
+              </a>
+            </Button>
+            <Button variant="outline" asChild>
+              <a href={`/decks/edit/${fileName}`}>
+                <Edit className="mr-2 h-4 w-4" />
+                Edit
+              </a>
+            </Button>
+            <Button variant="outline" onClick={handleExport}>
+              <Download className="mr-2 h-4 w-4" />
+              Export
+            </Button>
+          </div>
+        </div>
+        <div className="max-w-4xl mx-auto space-y-6">
+          <h2 className="text-2xl font-semibold text-gray-900 dark:text-white">Concepts</h2>
+          <div className="grid gap-6">
+            {deck.concepts.map((concept, index) => (
+              <Card key={index} className="hover:shadow-md transition-shadow">
+                <CardHeader>
+                  <div className="flex items-start justify-between">
+                    <div className="flex-1">
+                      <CardTitle className="text-xl text-blue-600 dark:text-blue-400">{concept.term}</CardTitle>
+                      <CardDescription className="mt-2 text-base">{concept.definition}</CardDescription>
+                    </div>
+                    <Badge variant="outline" className="ml-4">#{index + 1}</Badge>
+                  </div>
+                </CardHeader>
+                {concept.variations && concept.variations.length > 0 && (
+                  <CardContent>
+                    <div className="space-y-3">
+                      <h4 className="font-medium text-gray-900 dark:text-white">Additional Information:</h4>
+                      <div className="grid gap-3">
+                        {concept.variations.map((variation, variationIndex) => (
+                          <div key={variationIndex} className="flex items-start gap-3">
+                            <Badge variant="secondary" className="capitalize text-xs">
+                              {variation.type.replace('-', ' ')}
+                            </Badge>
+                            <p className="text-sm text-gray-600 dark:text-gray-400 flex-1">{variation.text}</p>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  </CardContent>
+                )}
+              </Card>
+            ))}
+          </div>
+          {deck.concepts.length === 0 && (
+            <Card>
+              <CardContent className="text-center py-12">
+                <FileText className="mx-auto h-12 w-12 text-gray-400 mb-4" />
+                <p className="text-gray-500 dark:text-gray-400">This deck has no concepts yet.</p>
+                <Button asChild className="mt-4">
+                  <a href={`/decks/edit/${fileName}`}>
+                    <Edit className="mr-2 h-4 w-4" />
+                    Add Concepts
+                  </a>
+                </Button>
+              </CardContent>
+            </Card>
+          )}
+          <Card className="border-blue-200 bg-blue-50 dark:bg-blue-950 dark:border-blue-800">
+            <CardContent className="pt-6">
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-4 text-center">
+                <div>
+                  <div className="text-2xl font-bold text-blue-600 dark:text-blue-400">{deck.concepts.length}</div>
+                  <div className="text-sm text-blue-600 dark:text-blue-400">Total Concepts</div>
+                </div>
+                <div>
+                  <div className="text-2xl font-bold text-blue-600 dark:text-blue-400">{deck.concepts.reduce((total, concept) => total + (concept.variations?.length || 0), 0)}</div>
+                  <div className="text-sm text-blue-600 dark:text-blue-400">Total Variations</div>
+                </div>
+                <div>
+                  <div className="text-2xl font-bold text-blue-600 dark:text-blue-400">{deck.concepts.length * 2 + deck.concepts.reduce((total, concept) => total + (concept.variations?.length || 0), 0)}</div>
+                  <div className="text-sm text-blue-600 dark:text-blue-400">Potential Questions</div>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/apps/frontend/src/components/views/DeckManagerView.tsx
+++ b/apps/frontend/src/components/views/DeckManagerView.tsx
@@ -1,0 +1,227 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { DecksAPI } from '@/lib/api/decks';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Input } from '@/components/ui/input';
+import {
+  Plus,
+  Upload,
+  Download,
+  Edit,
+  Trash2,
+  RefreshCw,
+  FileText,
+  Bot
+} from 'lucide-react';
+import type { Deck } from '@/shared/schemas/deck';
+
+interface DeckWithFileName {
+  fileName: string;
+  deck: Deck;
+}
+
+interface Props {
+  onBack: () => void;
+  onViewDeck: (fileName: string) => void;
+}
+
+export default function DeckManagerView({ onBack, onViewDeck }: Props) {
+  const [decks, setDecks] = useState<DeckWithFileName[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [importing, setImporting] = useState(false);
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+
+  const loadDecks = async () => {
+    setLoading(true);
+    try {
+      const response = await DecksAPI.getAll();
+      if (response.success && response.data) {
+        setDecks(response.data);
+      }
+    } catch (error) {
+      console.error('Failed to load decks:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadDecks();
+  }, []);
+
+  const handleImport = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    setImporting(true);
+    try {
+      const response = await DecksAPI.import(file);
+      if (response.success) {
+        await loadDecks();
+        alert('Deck imported successfully!');
+      } else {
+        alert(`Import failed: ${response.error}`);
+      }
+    } catch (error) {
+      alert('Import failed: Network error');
+    } finally {
+      setImporting(false);
+      event.target.value = '';
+    }
+  };
+
+  const handleDelete = async (fileName: string, deckTitle: string) => {
+    if (!confirm(`Are you sure you want to delete "${deckTitle}"?`)) return;
+    try {
+      const response = await DecksAPI.delete(fileName);
+      if (response.success) {
+        await loadDecks();
+        alert('Deck deleted successfully!');
+      } else {
+        alert(`Delete failed: ${response.error}`);
+      }
+    } catch (error) {
+      alert('Delete failed: Network error');
+    }
+  };
+
+  const handleExport = async (fileName: string, deck: Deck) => {
+    try {
+      await DecksAPI.export(fileName, deck);
+    } catch (error) {
+      alert('Export failed');
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex items-center justify-center">
+        <div className="flex items-center gap-2">
+          <RefreshCw className="h-4 w-4 animate-spin" />
+          Loading decks...
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
+      <div className="md:hidden bg-white dark:bg-gray-950 border-b border-gray-200 dark:border-gray-800 px-4 py-3 flex items-center justify-between sticky top-0 z-30">
+        <Button variant="ghost" size="icon" onClick={() => setSidebarOpen(true)}>
+          <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="2">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+          <span className="sr-only">Open menu</span>
+        </Button>
+        <span className="font-semibold">Deck Manager</span>
+        <div />
+        {sidebarOpen && (
+          <div className="fixed inset-0 z-40 flex">
+            <div className="absolute inset-0 bg-black/50" onClick={() => setSidebarOpen(false)} />
+            <aside className="relative w-72 max-w-full h-full bg-white dark:bg-gray-900 shadow-lg p-6 space-y-4">
+              <h2 className="text-lg font-semibold mb-4">Menu</h2>
+              <nav className="space-y-2">
+                <button onClick={() => { setSidebarOpen(false); onBack(); }} className="block w-full text-left px-3 py-2 rounded-md hover:bg-gray-100 dark:hover:bg-gray-800">Home</button>
+                <button onClick={() => setSidebarOpen(false)} className="block w-full text-left px-3 py-2 rounded-md hover:bg-gray-100 dark:hover:bg-gray-800">Decks</button>
+                <a href="/decks/create" className="block px-3 py-2 rounded-md hover:bg-gray-100 dark:hover:bg-gray-800">Create Deck</a>
+                <a href="/decks/ai-generate" className="block px-3 py-2 rounded-md hover:bg-gray-100 dark:hover:bg-gray-800">Generate with AI</a>
+              </nav>
+            </aside>
+          </div>
+        )}
+      </div>
+      <div className="container mx-auto px-4 py-8">
+        <div className="mb-8">
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-white mb-2">Deck Manager</h1>
+          <p className="text-gray-600 dark:text-gray-400">Create, edit, and manage your learning decks. All changes are saved to JSON files.</p>
+        </div>
+        <div className="flex flex-wrap gap-4 mb-8">
+          <Button asChild>
+            <a href="/decks/create">
+              <Plus className="mr-2 h-4 w-4" />
+              Create New Deck
+            </a>
+          </Button>
+          <div className="relative">
+            <Button variant="outline" disabled={importing}>
+              <Upload className="mr-2 h-4 w-4" />
+              {importing ? 'Importing...' : 'Import JSON'}
+            </Button>
+            <Input type="file" accept=".json" onChange={handleImport} className="absolute inset-0 opacity-0 cursor-pointer" disabled={importing} />
+          </div>
+          <Button variant="outline" onClick={loadDecks}>
+            <RefreshCw className="mr-2 h-4 w-4" />
+            Refresh
+          </Button>
+          <Button variant="outline" asChild>
+            <a href="/decks/ai-generate">
+              <Bot className="mr-2 h-4 w-4" />
+              Generate with AI
+            </a>
+          </Button>
+          <Button variant="ghost" onClick={onBack}>
+            Back
+          </Button>
+        </div>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {decks.map(({ fileName, deck }) => (
+            <Card key={deck.id} className="hover:shadow-lg transition-shadow">
+              <CardHeader>
+                <CardTitle className="text-xl">{deck.title}</CardTitle>
+                <CardDescription>{deck.description}</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <div className="flex items-center justify-between mb-4">
+                  <Badge variant="secondary">{deck.concepts.length} concept{deck.concepts.length !== 1 ? 's' : ''}</Badge>
+                  <Badge variant="outline" className="text-xs">{fileName}.json</Badge>
+                </div>
+                <div className="grid grid-cols-2 gap-2 mb-3">
+                  <Button asChild size="sm" className="w-full">
+                    <a href={`/game/flashcard/${fileName}`}>Flashcards</a>
+                  </Button>
+                  <Button asChild variant="outline" size="sm" className="w-full">
+                    <a href={`/game/quiz/${fileName}`}>Quiz</a>
+                  </Button>
+                </div>
+                <div className="grid grid-cols-4 gap-1">
+                  <Button asChild variant="ghost" size="sm">
+                    <a href={`/decks/edit/${fileName}`}>
+                      <Edit className="h-4 w-4" />
+                    </a>
+                  </Button>
+                  <Button variant="ghost" size="sm" onClick={() => handleExport(fileName, deck)}>
+                    <Download className="h-4 w-4" />
+                  </Button>
+                  <Button variant="ghost" size="sm" onClick={() => onViewDeck(fileName)}>
+                    <FileText className="h-4 w-4" />
+                  </Button>
+                  <Button variant="ghost" size="sm" onClick={() => handleDelete(fileName, deck.title)} className="text-red-600 hover:text-red-700">
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+        {decks.length === 0 && (
+          <div className="text-center py-12">
+            <FileText className="mx-auto h-12 w-12 text-gray-400 mb-4" />
+            <p className="text-gray-500 dark:text-gray-400 text-lg mb-4">No decks found</p>
+            <p className="text-gray-400 dark:text-gray-500 mb-6">Create your first deck or import existing JSON files to get started.</p>
+            <div className="flex justify-center gap-4">
+              <Button asChild>
+                <a href="/decks/create">
+                  <Plus className="mr-2 h-4 w-4" />
+                  Create Deck
+                </a>
+              </Button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+

--- a/apps/frontend/src/components/views/HomeView.tsx
+++ b/apps/frontend/src/components/views/HomeView.tsx
@@ -1,0 +1,216 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Plus, BookOpen, Play, Clock, Users, Shapes, Target } from 'lucide-react';
+import { topics } from '@/lib/mock-data';
+import { Topic } from '@/lib/types';
+import { DecksAPI } from '@/lib/api/decks';
+import type { Deck } from '@/shared/schemas/deck';
+
+interface Props {
+  onManageDecks: () => void;
+}
+
+const DeckCard = ({ deck, fileName }: { deck: Deck; fileName: string }) => (
+  <Card className="hover:shadow-lg transition-all hover:scale-[1.02]">
+    <CardHeader>
+      <div className="flex items-start justify-between">
+        <div className="flex-1">
+          <CardTitle className="text-lg mb-2">{deck.title}</CardTitle>
+          <CardDescription className="mb-3">{deck.description}</CardDescription>
+          <div className="flex items-center gap-2 mb-2">
+            <Badge variant="outline" className="text-xs">
+              <Users className="mr-1 h-3 w-3" />
+              {deck.concepts.length} concepts
+            </Badge>
+          </div>
+        </div>
+      </div>
+    </CardHeader>
+    <CardContent>
+      <div className="flex items-center justify-between mb-4">
+        <span className="text-sm text-gray-500 flex items-center gap-1">
+          <BookOpen className="h-4 w-4" />
+          {deck.concepts.length * 2} flashcards
+        </span>
+      </div>
+      <div className="flex gap-2">
+        <Button variant="default" size="sm" asChild className="flex-1">
+          <a href={`/game/flashcard/${fileName}`}> 
+            <BookOpen className="mr-2 h-4 w-4" />
+            Study
+          </a>
+        </Button>
+        <Button variant="outline" size="sm" asChild className="flex-1">
+          <a href={`/game/quiz/${fileName}`}> 
+            <Play className="mr-2 h-4 w-4" />
+            Quiz
+          </a>
+        </Button>
+      </div>
+      <Button variant="secondary" size="sm" asChild className="w-full mt-2">
+        <a href={`/game/matching/${fileName}`}> 
+          <Shapes className="mr-2 h-4 w-4" />
+          Matching Game
+        </a>
+      </Button>
+    </CardContent>
+  </Card>
+);
+
+const TopicSection = ({ topic, deckItems }: { topic: Topic; deckItems: Array<{ fileName: string; deck: Deck }> }) => (
+  <div className="space-y-6">
+    <div className="flex items-center gap-3 mb-6">
+      <div className={`p-3 rounded-lg ${topic.color}`}> <span className="text-2xl">{topic.icon}</span> </div>
+      <div>
+        <h2 className="text-2xl font-bold text-gray-900 dark:text-white">{topic.name}</h2>
+        <p className="text-gray-600 dark:text-gray-400">{topic.description}</p>
+      </div>
+    </div>
+    {deckItems.length > 0 && (
+      <div className="space-y-4">
+        <div className="flex items-center gap-2">
+          <span className="text-sm text-gray-500">({deckItems.length} deck{deckItems.length !== 1 ? 's' : ''})</span>
+        </div>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {deckItems.map(({ fileName, deck }) => (
+            <DeckCard key={deck.id} deck={deck} fileName={fileName} />
+          ))}
+        </div>
+      </div>
+    )}
+  </div>
+);
+
+const StatsCard = ({ title, value, description, icon: Icon }: { title: string; value: string | number; description: string; icon: React.ElementType }) => (
+  <Card>
+    <CardContent className="p-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <p className="text-sm font-medium text-gray-600 dark:text-gray-400">{title}</p>
+          <p className="text-2xl font-bold text-gray-900 dark:text-white">{value}</p>
+          <p className="text-xs text-gray-500 dark:text-gray-400">{description}</p>
+        </div>
+        <Icon className="h-8 w-8 text-gray-400" />
+      </div>
+    </CardContent>
+  </Card>
+);
+
+export default function HomeView({ onManageDecks }: Props) {
+  const [deckItems, setDeckItems] = useState<Array<{ fileName: string; deck: Deck }>>([]);
+  const [loading, setLoading] = useState(true);
+  const [activeTab, setActiveTab] = useState<string>('all');
+
+  useEffect(() => {
+    const loadDecks = async () => {
+      try {
+        const response = await DecksAPI.getAll();
+        if (response.success && response.data) {
+          setDeckItems(response.data);
+        }
+      } catch (error) {
+        console.error('Failed to load decks:', error);
+      } finally {
+        setLoading(false);
+      }
+    };
+    loadDecks();
+  }, []);
+
+  const groupedDeckItems = topics.reduce((acc, topic) => {
+    acc[topic.id] = deckItems.filter(({ deck }) =>
+      deck.title.toLowerCase().includes(topic.name.toLowerCase()) ||
+      (deck.description && deck.description.toLowerCase().includes(topic.name.toLowerCase()))
+    );
+    return acc;
+  }, {} as Record<string, Array<{ fileName: string; deck: Deck }>>);
+
+  const totalConcepts = deckItems.reduce((acc, { deck }) => acc + deck.concepts.length, 0);
+  const avgConceptsPerDeck = deckItems.length > 0 ? Math.round(totalConcepts / deckItems.length) : 0;
+  const totalFlashcards = totalConcepts * 2;
+
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
+      <div className="container mx-auto px-4 py-8">
+        <div className="flex items-center justify-between mb-8">
+          <div>
+            <h1 className="text-3xl font-bold text-gray-900 dark:text-white">Learning App</h1>
+            <p className="text-gray-600 dark:text-gray-400 mt-2">Explore {deckItems.length} learning decks across {topics.length} topics</p>
+          </div>
+          <div className="flex gap-3">
+            <Button variant="outline" onClick={onManageDecks}>
+              <BookOpen className="mr-2 h-4 w-4" />
+              Manage Decks
+            </Button>
+            <Button asChild>
+              <a href="/create">
+                <Plus className="mr-2 h-4 w-4" />
+                Create Deck
+              </a>
+            </Button>
+          </div>
+        </div>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
+          <StatsCard title="Total Concepts" value={totalConcepts} description="Ready to study" icon={BookOpen} />
+          <StatsCard title="Flashcards" value={totalFlashcards} description="Generated from concepts" icon={Clock} />
+          <StatsCard title="Average Deck Size" value={avgConceptsPerDeck} description="Concepts per deck" icon={Target} />
+        </div>
+        <Tabs value={activeTab} onValueChange={setActiveTab} className="space-y-6">
+          <TabsList className="grid w-full grid-cols-4 lg:grid-cols-7">
+            <TabsTrigger value="all">All Topics</TabsTrigger>
+            {topics.map((topic) => (
+              <TabsTrigger key={topic.id} value={topic.id} className="flex items-center gap-2">
+                <span>{topic.icon}</span>
+                <span className="hidden sm:inline">{topic.name}</span>
+              </TabsTrigger>
+            ))}
+          </TabsList>
+          <TabsContent value="all" className="space-y-12">
+            {loading ? (
+              <div className="text-center py-12">
+                <p className="text-gray-500">Loading decks...</p>
+              </div>
+            ) : (
+              topics.map((topic) => {
+                const topicDeckItems = groupedDeckItems[topic.id];
+                return topicDeckItems.length > 0 ? (
+                  <TopicSection key={topic.id} topic={topic} deckItems={topicDeckItems} />
+                ) : null;
+              })
+            )}
+          </TabsContent>
+          {topics.map((topic) => (
+            <TabsContent key={topic.id} value={topic.id}>
+              {loading ? (
+                <div className="text-center py-12">
+                  <p className="text-gray-500">Loading decks...</p>
+                </div>
+              ) : (
+                <TopicSection topic={topic} deckItems={groupedDeckItems[topic.id]} />
+              )}
+            </TabsContent>
+          ))}
+        </Tabs>
+        {!loading && deckItems.length === 0 && (
+          <div className="text-center py-12">
+            <BookOpen className="mx-auto h-12 w-12 text-gray-400" />
+            <h3 className="mt-4 text-lg font-medium text-gray-900 dark:text-white">No decks yet</h3>
+            <p className="mt-2 text-gray-500">Create your first learning deck to get started</p>
+            <Button className="mt-4" asChild>
+              <a href="/create">
+                <Plus className="mr-2 h-4 w-4" />
+                Create Your First Deck
+              </a>
+            </Button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- build `HomeView`, `DeckManagerView`, and `DeckDetailsView` components
- replace `app/page.tsx` with a simple SPA that swaps these views
- navigation buttons now trigger view changes instead of using Next.js routes

## Testing
- `bun run lint` *(fails: many ESLint errors)*

------
https://chatgpt.com/codex/tasks/task_e_684abe23c104832ab2abdcd17103b2e4