### PR TITLE
Remove lint/TS ignore options

### DIFF
--- a/apps/frontend/next.config.mjs
+++ b/apps/frontend/next.config.mjs
@@ -8,11 +8,12 @@ const __dirname = dirname(__filename);
 const nextConfig = {
   transpilePackages: ['@/shared'],
   serverExternalPackages: ['zod'],
+  // Allow build to fail on lint or type errors
   eslint: {
-    ignoreDuringBuilds: true,
+    // ignoreDuringBuilds: true,
   },
   typescript: {
-    ignoreBuildErrors: true,
+    // ignoreBuildErrors: true,
   },
   experimental: {
     // ... existing experimental options can remain here


### PR DESCRIPTION
## Summary
- comment out ignore flags from Next.js config

## Testing
- `bun run lint` *(fails as expected)*
- `bun x tsc -p apps/frontend/tsconfig.json --noEmit` *(fails as expected)*

------
https://chatgpt.com/codex/tasks/task_e_68607abc5e2c832ab5ac9c41113c5e81